### PR TITLE
Second level ID autodiscover, logrus hook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,10 @@ before_install:
 
 install:
   - mkdir -p $GOPATH/bin
-  - go get github.com/mattn/goveralls
   - go get github.com/go-playground/overalls
   - make deps
 
 script:
   - make test
   - $GOPATH/bin/overalls -project=github.com/hellofresh/stats-go -covermode=count
-  - $GOPATH/bin/goveralls -coverprofile=overalls.coverprofile -service=travis-ci -repotoken $COVERALLS_TOKEN
+  - bash <(curl -s https://codecov.io/bash) -f overalls.coverprofile

--- a/README.md
+++ b/README.md
@@ -239,7 +239,9 @@ func main() {
         }
         statsClient, _ := stats.NewClient(os.Getenv("STATS_DSN"), os.Getenv("STATS_PREFIX"))
         statsClient.SetHTTPMetricCallback(bucket.NewHasIDAtSecondLevelCallback(&bucket.SecondLevelIDConfig{
-                HasIDAtSecondLevel: sectionsTestsMap,
+                HasIDAtSecondLevel:    sectionsTestsMap,
+                AutoDiscoverThreshold: 25,
+                AutoDiscoverWhiteList: []string{"products"},
         }))
         defer statsClient.Close()
 
@@ -257,6 +259,15 @@ func main() {
         router.GET("/clients/:id", func(c *gin.Context) {
                 // will produce "<prefix>.get.clients.-id-" metric
                 c.JSON(http.StatusOK, "Get the client ID " + c.Params.ByName("id"))
+        })
+        router.GET("/ingredients/:id", func(c *gin.Context) {
+                // will produce "<prefix>.get.ingredients.<id>" metric for the first AutoDiscoverThreshold requests
+                // and then will produce "<prefix>.get.ingredients.-id-" metric for the rest of requests
+                c.JSON(http.StatusOK, "Get the ingredient ID " + c.Params.ByName("id"))
+        })
+        router.GET("/products/:id", func(c *gin.Context) {
+                // will produce "<prefix>.get.products.<id>" metric
+                c.JSON(http.StatusOK, "Get the product ID " + c.Params.ByName("id"))
         })
 
         router.Run(":8080")

--- a/README.md
+++ b/README.md
@@ -63,16 +63,6 @@ func main() {
         noopClient, _ := stats.NewClient("noop://", "")
         defer noopClient.Close()
 
-        // client that tries to connect to statsd service, fallback to debug log backend if fails to connect
-        // format for backward compatibility with previous version
-        legacyStatsdClient, _ := stats.NewClient("statsd-host:8125", "my.app.prefix")
-        defer legacyStatsdClient.Close()
-
-        // debug log backend for stats
-        // format for backward compatibility with previous version
-        legacyLogClient, _ := stats.NewClient("", "")
-        defer legacyLogClient.Close()
-
         // get settings from env to determine backend and prefix
         statsClient, _ := stats.NewClient(os.Getenv("STATS_DSN"), os.Getenv("STATS_PREFIX"))
         defer statsClient.Close()

--- a/README.md
+++ b/README.md
@@ -238,7 +238,9 @@ func main() {
                 sectionsTestsMap = map[bucket.PathSection]bucket.SectionTestDefinition{}
         }
         statsClient, _ := stats.NewClient(os.Getenv("STATS_DSN"), os.Getenv("STATS_PREFIX"))
-        statsClient.SetHTTPMetricCallback(bucket.NewHasIDAtSecondLevelCallback(sectionsTestsMap))
+        statsClient.SetHTTPMetricCallback(bucket.NewHasIDAtSecondLevelCallback(&bucket.SecondLevelIDConfig{
+                HasIDAtSecondLevel: sectionsTestsMap,
+        }))
         defer statsClient.Close()
 
         router := gin.Default()

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 # hellofresh/stats-go
 
 [![Build Status](https://travis-ci.org/hellofresh/stats-go.svg?branch=master)](https://travis-ci.org/hellofresh/stats-go)
-[![Coverage Status](https://coveralls.io/repos/github/hellofresh/stats-go/badge.svg?branch=master)](https://coveralls.io/github/hellofresh/stats-go?branch=master)
+[![Coverage Status](https://codecov.io/gh/hellofresh/stats-go/branch/master/graph/badge.svg)](https://codecov.io/gh/hellofresh/stats-go)
 [![GoDoc](https://godoc.org/github.com/hellofresh/stats-go?status.svg)](https://godoc.org/github.com/hellofresh/stats-go)
 [![Go Report Card](https://goreportcard.com/badge/github.com/hellofresh/stats-go)](https://goreportcard.com/report/github.com/hellofresh/stats-go)
 

--- a/bucket/metric_storage.go
+++ b/bucket/metric_storage.go
@@ -1,24 +1,23 @@
 package bucket
 
-const maxUniqueMetrics = 25
-
 type metricStorage struct {
-	metrics map[string]map[string]uint
+	threshold uint
+	metrics   map[string]map[string]uint
 }
 
-func newMetricStorage() *metricStorage {
-	return &metricStorage{metrics: make(map[string]map[string]uint)}
+func newMetricStorage(threshold uint) *metricStorage {
+	return &metricStorage{threshold: threshold, metrics: make(map[string]map[string]uint)}
 }
 
 func (s *metricStorage) LooksLikeID(firstSection, secondSection string) bool {
 	if _, ok := s.metrics[firstSection]; !ok {
-		s.metrics[firstSection] = make(map[string]uint, maxUniqueMetrics)
+		s.metrics[firstSection] = make(map[string]uint, s.threshold)
 	}
 
 	// avoid storing all values to avoid memory loss
-	if len(s.metrics[firstSection]) < maxUniqueMetrics {
+	if uint(len(s.metrics[firstSection])) < s.threshold {
 		s.metrics[firstSection][secondSection]++
 	}
 
-	return len(s.metrics[firstSection]) >= maxUniqueMetrics
+	return uint(len(s.metrics[firstSection])) >= s.threshold
 }

--- a/bucket/metric_storage.go
+++ b/bucket/metric_storage.go
@@ -1,0 +1,24 @@
+package bucket
+
+const maxUniqueMetrics = 25
+
+type metricStorage struct {
+	metrics map[string]map[string]uint
+}
+
+func newMetricStorage() *metricStorage {
+	return &metricStorage{metrics: make(map[string]map[string]uint)}
+}
+
+func (s *metricStorage) LooksLikeID(firstSection, secondSection string) bool {
+	if _, ok := s.metrics[firstSection]; !ok {
+		s.metrics[firstSection] = make(map[string]uint, maxUniqueMetrics)
+	}
+
+	// avoid storing all values to avoid memory loss
+	if len(s.metrics[firstSection]) < maxUniqueMetrics {
+		s.metrics[firstSection][secondSection]++
+	}
+
+	return len(s.metrics[firstSection]) >= maxUniqueMetrics
+}

--- a/bucket/metric_storage_test.go
+++ b/bucket/metric_storage_test.go
@@ -8,15 +8,15 @@ import (
 )
 
 func TestMetricStorage_LooksLikeID(t *testing.T) {
-	storage := newMetricStorage()
+	storage := newMetricStorage(25)
 	firstSection := time.Now().Format(time.RFC3339Nano)
 
-	for i := 0; i < maxUniqueMetrics-1; i++ {
+	for i := uint(0); i < storage.threshold-1; i++ {
 		assert.False(t, storage.LooksLikeID(firstSection, time.Now().Format(time.RFC3339Nano)))
 	}
 
 	assert.True(t, storage.LooksLikeID(firstSection, time.Now().Format(time.RFC3339Nano)))
 	assert.True(t, storage.LooksLikeID(firstSection, time.Now().Format(time.RFC3339Nano)))
 
-	assert.Equal(t, maxUniqueMetrics, len(storage.metrics[firstSection]))
+	assert.Equal(t, storage.threshold, uint(len(storage.metrics[firstSection])))
 }

--- a/bucket/metric_storage_test.go
+++ b/bucket/metric_storage_test.go
@@ -1,0 +1,22 @@
+package bucket
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetricStorage_LooksLikeID(t *testing.T) {
+	storage := newMetricStorage()
+	firstSection := time.Now().Format(time.RFC3339Nano)
+
+	for i := 0; i < maxUniqueMetrics-1; i++ {
+		assert.False(t, storage.LooksLikeID(firstSection, time.Now().Format(time.RFC3339Nano)))
+	}
+
+	assert.True(t, storage.LooksLikeID(firstSection, time.Now().Format(time.RFC3339Nano)))
+	assert.True(t, storage.LooksLikeID(firstSection, time.Now().Format(time.RFC3339Nano)))
+
+	assert.Equal(t, maxUniqueMetrics, len(storage.metrics[firstSection]))
+}

--- a/bucket/section_test_callback.go
+++ b/bucket/section_test_callback.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -53,6 +54,7 @@ func (m SectionsTestsMap) String() string {
 		sections = append(sections, fmt.Sprintf("%s: %s", k, v.Name))
 	}
 
+	sort.Strings(sections)
 	return fmt.Sprintf("[%s]", strings.Join(sections, ", "))
 }
 

--- a/bucket/section_test_callback.go
+++ b/bucket/section_test_callback.go
@@ -84,7 +84,7 @@ var (
 // SecondLevelIDConfig configuration struct for second level ID callback
 type SecondLevelIDConfig struct {
 	HasIDAtSecondLevel    SectionsTestsMap
-	AutoDiscoverEnabled   bool
+	AutoDiscoverThreshold uint
 	AutoDiscoverWhiteList []string
 
 	autoDiscoverStorage  *metricStorage
@@ -94,8 +94,8 @@ type SecondLevelIDConfig struct {
 // NewHasIDAtSecondLevelCallback returns HttpMetricNameAlterCallback implementation that checks for IDs
 // on the second level of HTTP Request path
 func NewHasIDAtSecondLevelCallback(config *SecondLevelIDConfig) HTTPMetricNameAlterCallback {
-	if config.AutoDiscoverEnabled {
-		config.autoDiscoverStorage = newMetricStorage()
+	if config.AutoDiscoverThreshold > 0 {
+		config.autoDiscoverStorage = newMetricStorage(config.AutoDiscoverThreshold)
 
 		// convert array to map for easier search
 		config.autoDiscoverWhiteMap = make(map[string]bool, len(config.AutoDiscoverWhiteList))
@@ -117,7 +117,7 @@ func NewHasIDAtSecondLevelCallback(config *SecondLevelIDConfig) HTTPMetricNameAl
 			if testFunction.Callback(PathSection(operation[2])) {
 				operation[2] = MetricIDPlaceholder
 			}
-		} else if config.AutoDiscoverEnabled {
+		} else if config.AutoDiscoverThreshold > 0 {
 			if _, ok := config.autoDiscoverWhiteMap[firstFragment]; !ok {
 				if config.autoDiscoverStorage.LooksLikeID(firstFragment, operation[2]) {
 					log.WithField("operation", operation).Error("Second level ID auto-discover found suspicious metric")

--- a/bucket/section_test_callback.go
+++ b/bucket/section_test_callback.go
@@ -7,17 +7,18 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+
+	log "github.com/sirupsen/logrus"
 )
 
 const (
-	sectionsDelimiter = ":"
+	sectionsDelimiter   = ":"
+	logSuspiciousMetric = "Second level ID auto-discover found suspicious metric"
 
 	// SectionTestTrue is a name for "stats.TestAlwaysTrue" test callback function
 	SectionTestTrue = "true"
-
 	// SectionTestIsNumeric is a name for "stats.TestIsNumeric" test callback function
 	SectionTestIsNumeric = "numeric"
-
 	// SectionTestIsNotEmpty is a name for "stats.TestIsNotEmpty" test callback function
 	SectionTestIsNotEmpty = "not_empty"
 )
@@ -80,9 +81,29 @@ var (
 	}
 )
 
+// SecondLevelIDConfig configuration struct for second level ID callback
+type SecondLevelIDConfig struct {
+	HasIDAtSecondLevel    SectionsTestsMap
+	AutoDiscoverEnabled   bool
+	AutoDiscoverWhiteList []string
+
+	autoDiscoverStorage  *metricStorage
+	autoDiscoverWhiteMap map[string]bool
+}
+
 // NewHasIDAtSecondLevelCallback returns HttpMetricNameAlterCallback implementation that checks for IDs
 // on the second level of HTTP Request path
-func NewHasIDAtSecondLevelCallback(hasIDAtSecondLevel SectionsTestsMap) HTTPMetricNameAlterCallback {
+func NewHasIDAtSecondLevelCallback(config *SecondLevelIDConfig) HTTPMetricNameAlterCallback {
+	if config.AutoDiscoverEnabled {
+		config.autoDiscoverStorage = newMetricStorage()
+
+		// convert array to map for easier search
+		config.autoDiscoverWhiteMap = make(map[string]bool, len(config.AutoDiscoverWhiteList))
+		for _, val := range config.AutoDiscoverWhiteList {
+			config.autoDiscoverWhiteMap[val] = true
+		}
+	}
+
 	return func(operation MetricOperation, r *http.Request) MetricOperation {
 		firstFragment := "/"
 		for _, fragment := range strings.Split(r.URL.Path, "/") {
@@ -91,9 +112,18 @@ func NewHasIDAtSecondLevelCallback(hasIDAtSecondLevel SectionsTestsMap) HTTPMetr
 				break
 			}
 		}
-		if testFunction, ok := hasIDAtSecondLevel[PathSection(firstFragment)]; ok {
+
+		if testFunction, ok := config.HasIDAtSecondLevel[PathSection(firstFragment)]; ok {
 			if testFunction.Callback(PathSection(operation[2])) {
 				operation[2] = MetricIDPlaceholder
+			}
+		} else if config.AutoDiscoverEnabled {
+			if _, ok := config.autoDiscoverWhiteMap[firstFragment]; !ok {
+				if config.autoDiscoverStorage.LooksLikeID(firstFragment, operation[2]) {
+					log.WithField("operation", operation).Error("Second level ID auto-discover found suspicious metric")
+
+					operation[2] = MetricIDPlaceholder
+				}
 			}
 		}
 

--- a/bucket/section_test_callback_test.go
+++ b/bucket/section_test_callback_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -26,7 +27,7 @@ func Test_sectionsTestRegistry(t *testing.T) {
 
 func parseAndAssertParseResults(t *testing.T, s string) {
 	m, err := ParseSectionsTestsMap(s)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.NotEmpty(t, reflect.ValueOf(m).MapKeys())
 
 	callback, ok := m["foo"]
@@ -78,4 +79,11 @@ func TestRegisterSectionTest_ErrUnknownSectionTest(t *testing.T) {
 
 	_, err = ParseSectionsTestsMap("foo:true:baz:NOT_EISTS")
 	assert.Equal(t, err, ErrUnknownSectionTest)
+}
+
+func TestSectionsTestsMap_String(t *testing.T) {
+	m, err := ParseSectionsTestsMap("foo:true:bar:numeric:baz:not_empty")
+	require.NoError(t, err)
+
+	assert.Equal(t, "[foo: true, bar: numeric, baz: not_empty]", m.String())
 }

--- a/bucket/section_test_callback_test.go
+++ b/bucket/section_test_callback_test.go
@@ -85,5 +85,5 @@ func TestSectionsTestsMap_String(t *testing.T) {
 	m, err := ParseSectionsTestsMap("foo:true:bar:numeric:baz:not_empty")
 	require.NoError(t, err)
 
-	assert.Equal(t, "[foo: true, bar: numeric, baz: not_empty]", m.String())
+	assert.Equal(t, "[bar: numeric, baz: not_empty, foo: true]", m.String())
 }

--- a/build/test.sh
+++ b/build/test.sh
@@ -27,7 +27,7 @@ FAIL="${ERROR_COLOR}FAIL ${NO_COLOR}"
 TARGETS=$@
 
 echo "${OK_COLOR}Running tests: ${NO_COLOR}"
-go test -v -race ${TARGETS}
+go test -race -cover ${TARGETS}
 
 echo "${OK_COLOR}Formatting: ${NO_COLOR}"
 ERRS=$(find . -type f -name \*.go | grep -v vendor | xargs gofmt -l 2>&1 || true)

--- a/client.go
+++ b/client.go
@@ -38,6 +38,11 @@ type Client interface {
 	// TrackOperationN tracks custom operation with n diff
 	TrackOperationN(section string, operation bucket.MetricOperation, t timer.Timer, n int, success bool) Client
 
+	// TrackMetric tracks custom metric, w/out ok/fail additional sections
+	TrackMetric(section string, operation bucket.MetricOperation) Client
+	// TrackMetricN tracks custom metric with n diff, w/out ok/fail additional sections
+	TrackMetricN(section string, operation bucket.MetricOperation, n int) Client
+
 	// TrackState tracks metric absolute value
 	TrackState(section string, operation bucket.MetricOperation, value int) Client
 

--- a/client.go
+++ b/client.go
@@ -2,7 +2,6 @@ package stats
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 
@@ -55,19 +54,9 @@ type Client interface {
 
 // NewClient creates and builds new stats client instance by given dsn
 func NewClient(dsn, prefix string) (Client, error) {
-	// for backward compatibility
-	if dsn == "" {
-		return NewStatsdClient(dsn, prefix), nil
-	}
-
 	dsnURL, err := url.Parse(dsn)
 	if err != nil {
 		return nil, err
-	}
-
-	// backward compatibility statsd dsn - "<statsd.host>:<port>"
-	if fmt.Sprintf("%s:%s", dsnURL.Scheme, dsnURL.Opaque) == dsn {
-		return NewStatsdClient(dsn, prefix), nil
 	}
 
 	switch dsnURL.Scheme {

--- a/client_test.go
+++ b/client_test.go
@@ -7,18 +7,11 @@ import (
 )
 
 func TestNewClient(t *testing.T) {
-	client, err := NewClient("", "")
+	client, err := NewClient("statsd://", "")
 	assert.NoError(t, err)
 	assert.IsType(t, &StatsdClient{}, client)
 
 	statsdClient, _ := client.(*StatsdClient)
-	assert.True(t, statsdClient.muted)
-
-	client, err = NewClient("statsd://", "")
-	assert.NoError(t, err)
-	assert.IsType(t, &StatsdClient{}, client)
-
-	statsdClient, _ = client.(*StatsdClient)
 	assert.True(t, statsdClient.muted)
 
 	client, err = NewClient("log://", "")

--- a/glide.lock
+++ b/glide.lock
@@ -1,16 +1,16 @@
 hash: 9cdd3716cbbbec032ce72480cec367a87d4b9740213a435b0917b0da557f1346
-updated: 2017-06-14T17:57:57.194245211+02:00
+updated: 2017-07-12T18:26:32.249032363+02:00
 imports:
 - name: github.com/fiam/gounidecode
   version: 8deddbd03fec2c28969266e52f27b6fb22be1823
   subpackages:
   - unidecode
 - name: github.com/sirupsen/logrus
-  version: 202f25545ea4cf9b191ff7f846df5d87c9382c2b
+  version: 7f976d3a76720c4c27af2ba716b85d2e0a7e38b1
   subpackages:
   - hooks/test
 - name: golang.org/x/sys
-  version: 0b25a408a50076fbbcae6b7ac0ea5fbb0b085e79
+  version: 94b76065f2d2081d0fef24a6e67c571f51a6408a
   subpackages:
   - unix
 - name: gopkg.in/alexcesaro/statsd.v2
@@ -28,3 +28,4 @@ testImports:
   version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:
   - assert
+  - require

--- a/hooks/logrus.go
+++ b/hooks/logrus.go
@@ -1,0 +1,29 @@
+package hooks
+
+import (
+	"github.com/hellofresh/stats-go"
+	"github.com/hellofresh/stats-go/bucket"
+	"github.com/sirupsen/logrus"
+)
+
+// LogrusHook is logrus hook for gathering stats on logged error
+type LogrusHook struct {
+	statsClient stats.Client
+	section     string
+}
+
+// NewLogrusHook creates a stats logger.
+func NewLogrusHook(statsClient stats.Client, section string) *LogrusHook {
+	return &LogrusHook{statsClient: statsClient, section: section}
+}
+
+// Levels is logrus.Hook method implementation
+func (h *LogrusHook) Levels() []logrus.Level {
+	return []logrus.Level{logrus.PanicLevel, logrus.FatalLevel, logrus.ErrorLevel}
+}
+
+// Fire is logrus.Hook method implementation
+func (h *LogrusHook) Fire(e *logrus.Entry) error {
+	h.statsClient.TrackMetric(h.section, bucket.MetricOperation{e.Level.String()})
+	return nil
+}

--- a/hooks/logrus_test.go
+++ b/hooks/logrus_test.go
@@ -1,0 +1,38 @@
+package hooks
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/hellofresh/stats-go"
+	"github.com/hellofresh/stats-go/bucket"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewLogrusHook(t *testing.T) {
+	client := stats.NewMemoryClient()
+	section := "errors"
+	b := bucket.NewPlain(section, bucket.MetricOperation{log.ErrorLevel.String()}, true)
+
+	hook := NewLogrusHook(client, section)
+	log.AddHook(hook)
+	log.SetLevel(log.DebugLevel)
+	log.SetOutput(ioutil.Discard)
+
+	log.Debug("debug")
+	log.Info("info")
+	log.Warn("warn")
+	log.Error("error")
+
+	assert.Equal(t, 2, len(client.CountMetrics))
+	assert.Equal(t, 1, client.CountMetrics[b.Metric()])
+	assert.Equal(t, 1, client.CountMetrics[b.MetricTotal()])
+
+	log.Errorf("error section: %s", section)
+	log.Errorln("error line")
+
+	assert.Equal(t, 2, len(client.CountMetrics))
+	assert.Equal(t, 3, client.CountMetrics[b.Metric()])
+	assert.Equal(t, 3, client.CountMetrics[b.MetricTotal()])
+}

--- a/memory_client.go
+++ b/memory_client.go
@@ -105,6 +105,34 @@ func (c *MemoryClient) TrackOperationN(section string, operation bucket.MetricOp
 	return c
 }
 
+// TrackMetric tracks custom metric, w/out ok/fail additional sections
+func (c *MemoryClient) TrackMetric(section string, operation bucket.MetricOperation) Client {
+	b := bucket.NewPlain(section, operation, true)
+	i := incrementer.NewMemory()
+
+	i.Increment(b.Metric())
+	i.Increment(b.MetricTotal())
+	for metric, value := range i.Metrics() {
+		c.CountMetrics[metric] += value
+	}
+
+	return c
+}
+
+// TrackMetricN tracks custom metric with n diff, w/out ok/fail additional sections
+func (c *MemoryClient) TrackMetricN(section string, operation bucket.MetricOperation, n int) Client {
+	b := bucket.NewPlain(section, operation, true)
+	i := incrementer.NewMemory()
+
+	i.IncrementN(b.Metric(), n)
+	i.IncrementN(b.MetricTotal(), n)
+	for metric, value := range i.Metrics() {
+		c.CountMetrics[metric] += value
+	}
+
+	return c
+}
+
 // TrackState tracks metric absolute value
 func (c *MemoryClient) TrackState(section string, operation bucket.MetricOperation, value int) Client {
 	b := bucket.NewPlain(section, operation, true)

--- a/memory_client_test.go
+++ b/memory_client_test.go
@@ -96,6 +96,53 @@ func TestMemoryClient_TrackOperationN(t *testing.T) {
 	assert.Equal(t, 0, len(client.CountMetrics))
 }
 
+func TestMemoryClient_TrackMetric(t *testing.T) {
+	client := NewMemoryClient()
+
+	section := "test-section"
+	operation := bucket.MetricOperation{"o1", "o2", "o3"}
+	b := bucket.NewPlain(section, operation, true)
+
+	client.TrackMetric(section, operation)
+
+	assert.Equal(t, 0, len(client.TimerMetrics))
+	assert.Equal(t, 2, len(client.CountMetrics))
+
+	assert.Equal(t, 1, client.CountMetrics[b.Metric()])
+	assert.Equal(t, 0, client.CountMetrics[b.MetricWithSuffix()])
+	assert.Equal(t, 1, client.CountMetrics[b.MetricTotal()])
+	assert.Equal(t, 0, client.CountMetrics[b.MetricTotalWithSuffix()])
+
+	client.Close()
+
+	assert.Equal(t, 0, len(client.TimerMetrics))
+	assert.Equal(t, 0, len(client.CountMetrics))
+}
+
+func TestMemoryClient_TrackMetricN(t *testing.T) {
+	client := NewMemoryClient()
+
+	section := "test-section"
+	operation := bucket.MetricOperation{"o1", "o2", "o3"}
+	n := 5
+	b := bucket.NewPlain(section, operation, true)
+
+	client.TrackMetricN(section, operation, n)
+
+	assert.Equal(t, 0, len(client.TimerMetrics))
+	assert.Equal(t, 2, len(client.CountMetrics))
+
+	assert.Equal(t, n, client.CountMetrics[b.Metric()])
+	assert.Equal(t, 0, client.CountMetrics[b.MetricWithSuffix()])
+	assert.Equal(t, n, client.CountMetrics[b.MetricTotal()])
+	assert.Equal(t, 0, client.CountMetrics[b.MetricTotalWithSuffix()])
+
+	client.Close()
+
+	assert.Equal(t, 0, len(client.TimerMetrics))
+	assert.Equal(t, 0, len(client.CountMetrics))
+}
+
 func TestMemoryClient_TrackState(t *testing.T) {
 	client := NewMemoryClient()
 

--- a/noop_client.go
+++ b/noop_client.go
@@ -44,6 +44,16 @@ func (c *NoopClient) TrackOperationN(section string, operation bucket.MetricOper
 	return c
 }
 
+// TrackMetric tracks custom metric, w/out ok/fail additional sections
+func (c *NoopClient) TrackMetric(section string, operation bucket.MetricOperation) Client {
+	return c
+}
+
+// TrackMetricN tracks custom metric with n diff, w/out ok/fail additional sections
+func (c *NoopClient) TrackMetricN(section string, operation bucket.MetricOperation, n int) Client {
+	return c
+}
+
 // TrackState tracks metric absolute value
 func (c *NoopClient) TrackState(section string, operation bucket.MetricOperation, value int) Client {
 	return c

--- a/noop_client_test.go
+++ b/noop_client_test.go
@@ -18,6 +18,8 @@ func TestNoopClient(t *testing.T) {
 	assert.Equal(t, client, client.TrackRequest(nil, nil, true))
 	assert.Equal(t, client, client.TrackOperation("", bucket.MetricOperation{}, nil, true))
 	assert.Equal(t, client, client.TrackOperationN("", bucket.MetricOperation{}, nil, 0, true))
+	assert.Equal(t, client, client.TrackMetric("", bucket.MetricOperation{}))
+	assert.Equal(t, client, client.TrackMetricN("", bucket.MetricOperation{}, 0))
 	assert.Equal(t, client, client.TrackState("", bucket.MetricOperation{}, 0))
 	assert.Equal(t, client, client.SetHTTPRequestSection(""))
 	assert.Equal(t, client, client.ResetHTTPRequestSection())

--- a/statsd_client.go
+++ b/statsd_client.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hellofresh/stats-go/state"
 	"github.com/hellofresh/stats-go/timer"
 	log "github.com/sirupsen/logrus"
-	statsd "gopkg.in/alexcesaro/statsd.v2"
+	"gopkg.in/alexcesaro/statsd.v2"
 )
 
 // StatsdClient is Client implementation for statsd
@@ -98,6 +98,28 @@ func (c *StatsdClient) TrackOperationN(section string, operation bucket.MetricOp
 		t.Finish(b.MetricWithSuffix())
 	}
 	i.IncrementAllN(b, n)
+
+	return c
+}
+
+// TrackMetric tracks custom metric, w/out ok/fail additional sections
+func (c *StatsdClient) TrackMetric(section string, operation bucket.MetricOperation) Client {
+	b := bucket.NewPlain(section, operation, true)
+	i := incrementer.New(c.client, c.muted)
+
+	i.Increment(b.Metric())
+	i.Increment(b.MetricTotal())
+
+	return c
+}
+
+// TrackMetricN tracks custom metric with n diff, w/out ok/fail additional sections
+func (c *StatsdClient) TrackMetricN(section string, operation bucket.MetricOperation, n int) Client {
+	b := bucket.NewPlain(section, operation, true)
+	i := incrementer.New(c.client, c.muted)
+
+	i.IncrementN(b.Metric(), n)
+	i.IncrementN(b.MetricTotal(), n)
 
 	return c
 }


### PR DESCRIPTION
* Auto-discover for second level IDs based on unique metrics threshold
* Logrus hook for error messages monitoring
* Some deprecated code cleanup
* Moved code coverage to codecov.io