### PR TITLE
Hotfix/memory allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Connection DSN has the following format: `<type>://<connection params>/<connecti
 * `<type>` - one of supported backends: `log`, `statsd`, `memory`, `noop`
 * `<connection params>` - used for `statsd` backend only, to defining host and port
 * `<connection path>` - used for `statsd` backend only, to define prefix/namespace
-* `<connection options>` - teh following options are available in the query string format: 
+* `<connection options>` - the following options are available in the query string format:
   * `unicode` - convert unicode metrics to ASCII, default value is `false` as it takes significant memory allocation number
 
 ```go

--- a/README.md
+++ b/README.md
@@ -38,18 +38,26 @@ go get -u github.com/hellofresh/stats-go
 
 #### Instance creation
 
+Connection DSN has the following format: `<type>://<connection params>/<connection path>?<connection options>`.
+
+* `<type>` - one of supported backends: `log`, `statsd`, `memory`, `noop`
+* `<connection params>` - used for `statsd` backend only, to defining host and port
+* `<connection path>` - used for `statsd` backend only, to define prefix/namespace
+* `<connection options>` - teh following options are available in the query string format: 
+  * `unicode` - convert unicode metrics to ASCII, default value is `false` as it takes significant memory allocation number
+
 ```go
 package main
 
 import (
         "os"
 
-        stats "github.com/hellofresh/stats-go"
+        "github.com/hellofresh/stats-go"
 )
 
 func main() {
         // client that tries to connect to statsd service, fallback to debug log backend if fails to connect
-        statsdClient, _ := stats.NewClient("statsd://statsd-host:8125/?prefix=my.app.prefix")
+        statsdClient, _ := stats.NewClient("statsd://statsd-host:8125/my.app.prefix?unicode=true")
         defer statsdClient.Close()
 
         // debug log backend for stats

--- a/README.md
+++ b/README.md
@@ -49,23 +49,23 @@ import (
 
 func main() {
         // client that tries to connect to statsd service, fallback to debug log backend if fails to connect
-        statsdClient, _ := stats.NewClient("statsd://statsd-host:8125", "my.app.prefix")
+        statsdClient, _ := stats.NewClient("statsd://statsd-host:8125/?prefix=my.app.prefix")
         defer statsdClient.Close()
 
         // debug log backend for stats
-        logClient, _ := stats.NewClient("log://", "")
+        logClient, _ := stats.NewClient("log://")
         defer logClient.Close()
 
         // memory backend to track operations in unit tests
-        memoryClient, _ := stats.NewClient("memory://", "")
+        memoryClient, _ := stats.NewClient("memory://")
         defer memoryClient.Close()
 
         // noop backend to ignore all stats
-        noopClient, _ := stats.NewClient("noop://", "")
+        noopClient, _ := stats.NewClient("noop://")
         defer noopClient.Close()
 
         // get settings from env to determine backend and prefix
-        statsClient, _ := stats.NewClient(os.Getenv("STATS_DSN"), os.Getenv("STATS_PREFIX"))
+        statsClient, _ := stats.NewClient(os.Getenv("STATS_DSN"))
         defer statsClient.Close()
 }
 ```
@@ -208,7 +208,7 @@ import (
 )
 
 func TestDoSomeJob(t *testing.T) {
-        statsClient, _ := stats.NewClient("memory://", "") 
+        statsClient, _ := stats.NewClient("memory://") 
 
         err := DoSomeJob(statsClient)
         assert.Nil(t, err)
@@ -271,7 +271,7 @@ func main() {
         if err != nil {
                 sectionsTestsMap = map[bucket.PathSection]bucket.SectionTestDefinition{}
         }
-        statsClient, _ := stats.NewClient(os.Getenv("STATS_DSN"), os.Getenv("STATS_PREFIX"))
+        statsClient, _ := stats.NewClient(os.Getenv("STATS_DSN"))
         statsClient.SetHTTPMetricCallback(bucket.NewHasIDAtSecondLevelCallback(&bucket.SecondLevelIDConfig{
                 HasIDAtSecondLevel:    sectionsTestsMap,
                 AutoDiscoverThreshold: 25,

--- a/bucket/bucket.go
+++ b/bucket/bucket.go
@@ -23,6 +23,8 @@ const (
 	MetricIDPlaceholder = "-id-"
 )
 
+var operationsStatus = map[bool]string{true: suffixStatusOk, false: suffixStatusFail}
+
 // Bucket is an interface for building metric names for operations
 type Bucket interface {
 	// Metric builds simple metric name in the form "<section>.<operation-0>.<operation-1>.<operation-2>"
@@ -39,15 +41,16 @@ type Bucket interface {
 }
 
 // SanitizeMetricName modifies metric name to work well with statsd
-func SanitizeMetricName(metric string) string {
+func SanitizeMetricName(metric string, uniDecode bool) string {
 	if metric == "" {
 		return MetricEmptyPlaceholder
 	}
 
-	// convert unicode symbols to ASCII
-	asciiMetric := unidecode.Unidecode(metric)
-	if asciiMetric != metric {
-		metric = prefixUnicode + asciiMetric
+	if uniDecode {
+		asciiMetric := unidecode.Unidecode(metric)
+		if asciiMetric != metric {
+			metric = prefixUnicode + asciiMetric
+		}
 	}
 
 	return strings.Replace(
@@ -58,8 +61,4 @@ func SanitizeMetricName(metric string) string {
 		"_",
 		-1,
 	)
-}
-
-func getOperationStatus(success bool) string {
-	return map[bool]string{true: suffixStatusOk, false: suffixStatusFail}[success]
 }

--- a/bucket/bucket_http_request.go
+++ b/bucket/bucket_http_request.go
@@ -18,14 +18,15 @@ type HTTPMetricNameAlterCallback func(metricParts MetricOperation, r *http.Reque
 // Normally "<section>" is set to "request", but you can use any string value here.
 type HTTPRequest struct {
 	*Plain
+
 	r        *http.Request
 	callback HTTPMetricNameAlterCallback
 }
 
 // NewHTTPRequest builds and returns new HTTPRequest instance
-func NewHTTPRequest(section string, r *http.Request, success bool, callback HTTPMetricNameAlterCallback) *HTTPRequest {
+func NewHTTPRequest(section string, r *http.Request, success bool, callback HTTPMetricNameAlterCallback, unicode bool) *HTTPRequest {
 	operation := BuildHTTPRequestMetricOperation(r, callback)
-	return &HTTPRequest{NewPlain(section, operation, success), r, callback}
+	return &HTTPRequest{NewPlain(section, operation, success, unicode), r, callback}
 }
 
 // BuildHTTPRequestMetricOperation builds metric operation from HTTP request

--- a/bucket/bucket_plain.go
+++ b/bucket/bucket_plain.go
@@ -1,7 +1,6 @@
 package bucket
 
 import (
-	"fmt"
 	"strings"
 )
 
@@ -16,34 +15,34 @@ type Plain struct {
 }
 
 // NewPlain builds and returns new Plain instance
-func NewPlain(section string, operation MetricOperation, success bool) *Plain {
+func NewPlain(section string, operation MetricOperation, success, uniDecode bool) *Plain {
 	operationSanitized := make([]string, cap(operation))
 	for k, v := range operation {
-		operationSanitized[k] = SanitizeMetricName(v)
+		operationSanitized[k] = SanitizeMetricName(v, uniDecode)
 	}
-	return &Plain{SanitizeMetricName(section), strings.Join(operationSanitized, "."), success}
+	return &Plain{SanitizeMetricName(section, uniDecode), strings.Join(operationSanitized, "."), success}
 }
 
 // Metric builds simple metric name in the form:
 //  <section>.<operation-0>.<operation-1>.<operation-2>
 func (b *Plain) Metric() string {
-	return fmt.Sprintf("%s.%s", b.section, b.operation)
+	return b.section + "." + b.operation
 }
 
 // MetricWithSuffix builds metric name with success suffix in the form:
 //  <section>-ok|fail.<operation-0>.<operation-1>.<operation-2>
 func (b *Plain) MetricWithSuffix() string {
-	return fmt.Sprintf("%s-%s.%s", b.section, getOperationStatus(b.success), b.operation)
+	return b.section + "-" + operationsStatus[b.success] + "." + b.operation
 }
 
 // MetricTotal builds simple total metric name in the form:
 //  total.<section>
 func (b *Plain) MetricTotal() string {
-	return fmt.Sprintf("%s.%s", totalBucket, b.section)
+	return totalBucket + "." + b.section
 }
 
 // MetricTotalWithSuffix builds total metric name with success suffix in the form
 //  total-ok|fail.<section>
 func (b *Plain) MetricTotalWithSuffix() string {
-	return fmt.Sprintf("%s.%s-%s", totalBucket, b.section, getOperationStatus(b.success))
+	return totalBucket + "." + b.section + "-" + operationsStatus[b.success]
 }

--- a/bucket/bucket_plain_test.go
+++ b/bucket/bucket_plain_test.go
@@ -21,8 +21,50 @@ func TestPlain_Metric(t *testing.T) {
 	}
 
 	for _, data := range dataProvider {
-		b := NewPlain(data.Section, data.Operation, data.Success)
+		b := NewPlain(data.Section, data.Operation, data.Success, true)
 		assert.Equal(t, data.Metric, b.Metric())
+	}
+}
+
+func BenchmarkNewPlain(b *testing.B) {
+	operation := MetricOperation{"bar", "baz", "qaz"}
+	for n := 0; n < b.N; n++ {
+		NewPlain("foo", operation, true, false)
+	}
+}
+
+func BenchmarkNewPlain_unicode(b *testing.B) {
+	operation := MetricOperation{"bar", "baz", "qaz"}
+	for n := 0; n < b.N; n++ {
+		NewPlain("foo", operation, true, true)
+	}
+}
+
+func BenchmarkPlain_Metric(b *testing.B) {
+	bucket := NewPlain("foo", MetricOperation{"bar", "baz", "qaz"}, true, false)
+	for n := 0; n < b.N; n++ {
+		bucket.Metric()
+	}
+}
+
+func BenchmarkPlain_MetricWithSuffix(b *testing.B) {
+	bucket := NewPlain("foo", MetricOperation{"bar", "baz", "qaz"}, true, false)
+	for n := 0; n < b.N; n++ {
+		bucket.MetricWithSuffix()
+	}
+}
+
+func BenchmarkPlain_MetricTotal(b *testing.B) {
+	bucket := NewPlain("foo", MetricOperation{"bar", "baz", "qaz"}, true, false)
+	for n := 0; n < b.N; n++ {
+		bucket.MetricTotal()
+	}
+}
+
+func BenchmarkPlain_MetricTotalWithSuffix(b *testing.B) {
+	bucket := NewPlain("foo", MetricOperation{"bar", "baz", "qaz"}, true, false)
+	for n := 0; n < b.N; n++ {
+		bucket.MetricTotalWithSuffix()
 	}
 }
 
@@ -38,7 +80,7 @@ func TestPlain_MetricWithSuffix(t *testing.T) {
 	}
 
 	for _, data := range dataProvider {
-		b := NewPlain(data.Section, data.Operation, data.Success)
+		b := NewPlain(data.Section, data.Operation, data.Success, true)
 		assert.Equal(t, data.Metric, b.MetricWithSuffix())
 	}
 }
@@ -55,7 +97,7 @@ func TestPlain_MetricTotal(t *testing.T) {
 	}
 
 	for _, data := range dataProvider {
-		b := NewPlain(data.Section, data.Operation, data.Success)
+		b := NewPlain(data.Section, data.Operation, data.Success, true)
 		assert.Equal(t, data.Metric, b.MetricTotal())
 	}
 }
@@ -72,7 +114,7 @@ func TestPlain_MetricTotalWithSuffix(t *testing.T) {
 	}
 
 	for _, data := range dataProvider {
-		b := NewPlain(data.Section, data.Operation, data.Success)
+		b := NewPlain(data.Section, data.Operation, data.Success, true)
 		assert.Equal(t, data.Metric, b.MetricTotalWithSuffix())
 	}
 }

--- a/bucket/bucket_test.go
+++ b/bucket/bucket_test.go
@@ -7,16 +7,20 @@ import (
 )
 
 func TestSanitizeMetricName(t *testing.T) {
-	assert.Equal(t, "-", SanitizeMetricName(""))
+	assert.Equal(t, "-", SanitizeMetricName("", false))
 
-	assert.Equal(t, "-u-iunikod", SanitizeMetricName("юникод"))
-	assert.Equal(t, "-u-Apollon", SanitizeMetricName("Ἀπόλλων"))
-	assert.Equal(t, "-u-acougue", SanitizeMetricName("açougue"))
+	assert.Equal(t, "-u-iunikod", SanitizeMetricName("юникод", true))
+	assert.Equal(t, "-u-Apollon", SanitizeMetricName("Ἀπόλλων", true))
+	assert.Equal(t, "-u-acougue", SanitizeMetricName("açougue", true))
 
-	assert.Equal(t, "metric", SanitizeMetricName("metric"))
-	assert.Equal(t, "metric_with_dots", SanitizeMetricName("metric.with.dots"))
-	assert.Equal(t, "metric__with__underscores", SanitizeMetricName("metric_with_underscores"))
-	assert.Equal(t, "metric_with_dots__and__underscores", SanitizeMetricName("metric.with.dots_and_underscores"))
+	assert.Equal(t, "юникод", SanitizeMetricName("юникод", false))
+	assert.Equal(t, "Ἀπόλλων", SanitizeMetricName("Ἀπόλλων", false))
+	assert.Equal(t, "açougue", SanitizeMetricName("açougue", false))
 
-	assert.Equal(t, "-u-iunikod_metrika", SanitizeMetricName("юникод.метрика"))
+	assert.Equal(t, "metric", SanitizeMetricName("metric", true))
+	assert.Equal(t, "metric_with_dots", SanitizeMetricName("metric.with.dots", true))
+	assert.Equal(t, "metric__with__underscores", SanitizeMetricName("metric_with_underscores", true))
+	assert.Equal(t, "metric_with_dots__and__underscores", SanitizeMetricName("metric.with.dots_and_underscores", true))
+
+	assert.Equal(t, "-u-iunikod_metrika", SanitizeMetricName("юникод.метрика", true))
 }

--- a/bucket/metric_storage_test.go
+++ b/bucket/metric_storage_test.go
@@ -12,11 +12,11 @@ func TestMetricStorage_LooksLikeID(t *testing.T) {
 	firstSection := time.Now().Format(time.RFC3339Nano)
 
 	for i := uint(0); i < storage.threshold-1; i++ {
-		assert.False(t, storage.LooksLikeID(firstSection, time.Now().Format(time.RFC3339Nano)))
+		assert.False(t, storage.LooksLikeID(firstSection, string(i)))
 	}
 
-	assert.True(t, storage.LooksLikeID(firstSection, time.Now().Format(time.RFC3339Nano)))
-	assert.True(t, storage.LooksLikeID(firstSection, time.Now().Format(time.RFC3339Nano)))
+	assert.True(t, storage.LooksLikeID(firstSection, string(storage.threshold+1)))
+	assert.True(t, storage.LooksLikeID(firstSection, string(storage.threshold+1)))
 
 	assert.Equal(t, storage.threshold, uint(len(storage.metrics[firstSection])))
 }

--- a/client.go
+++ b/client.go
@@ -4,6 +4,9 @@ import (
 	"errors"
 	"net/http"
 	"net/url"
+	"strings"
+
+	"strconv"
 
 	"github.com/hellofresh/stats-go/bucket"
 	"github.com/hellofresh/stats-go/timer"
@@ -64,15 +67,18 @@ func NewClient(dsn string) (Client, error) {
 		return nil, err
 	}
 
+	// do not care about parse error, as default value is set to false that is fine for us
+	unicode, _ := strconv.ParseBool(dsnURL.Query().Get("unicode"))
+
 	switch dsnURL.Scheme {
 	case StatsD:
-		return NewStatsdClient(dsnURL.Host, dsnURL.Query().Get("prefix")), nil
+		return NewStatsdClient(dsnURL.Host, strings.Trim(dsnURL.Path, "/"), unicode), nil
 	case Log:
-		return NewLogClient(), nil
+		return NewLogClient(unicode), nil
 	case Memory:
-		return NewMemoryClient(), nil
+		return NewMemoryClient(unicode), nil
 	case Noop:
-		return NewNoopClient(), nil
+		return NewNoopClient(unicode), nil
 	}
 
 	return nil, ErrUnknownClient

--- a/client.go
+++ b/client.go
@@ -21,7 +21,7 @@ const (
 )
 
 // ErrUnknownClient is an error returned when trying to create stats client of unknown type
-var ErrUnknownClient = errors.New("Unknown stats client type")
+var ErrUnknownClient = errors.New("unknown stats client type")
 
 // Client is an interface for different methods of gathering stats
 type Client interface {
@@ -58,7 +58,7 @@ type Client interface {
 }
 
 // NewClient creates and builds new stats client instance by given dsn
-func NewClient(dsn, prefix string) (Client, error) {
+func NewClient(dsn string) (Client, error) {
 	dsnURL, err := url.Parse(dsn)
 	if err != nil {
 		return nil, err
@@ -66,7 +66,7 @@ func NewClient(dsn, prefix string) (Client, error) {
 
 	switch dsnURL.Scheme {
 	case StatsD:
-		return NewStatsdClient(dsnURL.Host, prefix), nil
+		return NewStatsdClient(dsnURL.Host, dsnURL.Query().Get("prefix")), nil
 	case Log:
 		return NewLogClient(), nil
 	case Memory:

--- a/client.go
+++ b/client.go
@@ -4,9 +4,8 @@ import (
 	"errors"
 	"net/http"
 	"net/url"
-	"strings"
-
 	"strconv"
+	"strings"
 
 	"github.com/hellofresh/stats-go/bucket"
 	"github.com/hellofresh/stats-go/timer"

--- a/client_test.go
+++ b/client_test.go
@@ -7,26 +7,26 @@ import (
 )
 
 func TestNewClient(t *testing.T) {
-	client, err := NewClient("statsd://", "")
+	client, err := NewClient("statsd://")
 	assert.NoError(t, err)
 	assert.IsType(t, &StatsdClient{}, client)
 
 	statsdClient, _ := client.(*StatsdClient)
 	assert.True(t, statsdClient.muted)
 
-	client, err = NewClient("log://", "")
+	client, err = NewClient("log://")
 	assert.NoError(t, err)
 	assert.IsType(t, &LogClient{}, client)
 
-	client, err = NewClient("memory://", "")
+	client, err = NewClient("memory://")
 	assert.NoError(t, err)
 	assert.IsType(t, &MemoryClient{}, client)
 
-	client, err = NewClient("noop://", "")
+	client, err = NewClient("noop://")
 	assert.NoError(t, err)
 	assert.IsType(t, &NoopClient{}, client)
 
-	client, err = NewClient("unknown://", "")
+	client, err = NewClient("unknown://")
 	assert.Nil(t, client)
 	assert.Error(t, err)
 	assert.Equal(t, ErrUnknownClient, err)

--- a/hooks/logrus_test.go
+++ b/hooks/logrus_test.go
@@ -11,9 +11,9 @@ import (
 )
 
 func TestNewLogrusHook(t *testing.T) {
-	client := stats.NewMemoryClient()
+	client := stats.NewMemoryClient(true)
 	section := "errors"
-	b := bucket.NewPlain(section, bucket.MetricOperation{log.ErrorLevel.String()}, true)
+	b := bucket.NewPlain(section, bucket.MetricOperation{log.ErrorLevel.String()}, true, true)
 
 	hook := NewLogrusHook(client, section)
 	log.AddHook(hook)

--- a/incrementer/incrementer_test.go
+++ b/incrementer/incrementer_test.go
@@ -47,7 +47,7 @@ func (i *mockIncrementer) IncrementAllN(b bucket.Bucket, n int) {
 }
 
 func Test_incrementAll(t *testing.T) {
-	b := bucket.NewPlain("section", bucket.MetricOperation{"o1", "o2", "o3"}, true)
+	b := bucket.NewPlain("section", bucket.MetricOperation{"o1", "o2", "o3"}, true, true)
 
 	i := &mockIncrementer{}
 	i.IncrementAll(b)
@@ -60,7 +60,7 @@ func Test_incrementAll(t *testing.T) {
 }
 
 func Test_incrementAllN(t *testing.T) {
-	b := bucket.NewPlain("section", bucket.MetricOperation{"o1", "o2", "o3"}, true)
+	b := bucket.NewPlain("section", bucket.MetricOperation{"o1", "o2", "o3"}, true, true)
 	n := 42
 
 	i := &mockIncrementer{}

--- a/incrementer/log_test.go
+++ b/incrementer/log_test.go
@@ -32,7 +32,7 @@ func TestLog(t *testing.T) {
 
 	hook.Reset()
 
-	bb := bucket.NewPlain("section", bucket.MetricOperation{"o1", "o2", "o3"}, true)
+	bb := bucket.NewPlain("section", bucket.MetricOperation{"o1", "o2", "o3"}, true, true)
 	i.IncrementAll(bb)
 
 	assert.Equal(t, 4, len(hook.Entries))

--- a/incrementer/memory_test.go
+++ b/incrementer/memory_test.go
@@ -35,8 +35,8 @@ func TestMemory_Increment(t *testing.T) {
 
 func TestMemory_IncrementAll(t *testing.T) {
 	i := NewMemory()
-	b1 := bucket.NewPlain("section1", bucket.MetricOperation{"o11", "o12", "o13"}, true)
-	b2 := bucket.NewPlain("section2", bucket.MetricOperation{"o21", "o22", "o23"}, false)
+	b1 := bucket.NewPlain("section1", bucket.MetricOperation{"o11", "o12", "o13"}, true, true)
+	b2 := bucket.NewPlain("section2", bucket.MetricOperation{"o21", "o22", "o23"}, false, true)
 	metricN := 5
 
 	allB1 := []string{b1.Metric(), b1.MetricWithSuffix(), b1.MetricTotal(), b1.MetricTotalWithSuffix()}

--- a/log_client.go
+++ b/log_client.go
@@ -6,8 +6,8 @@ type LogClient struct {
 }
 
 // NewLogClient builds and returns new LogClient instance
-func NewLogClient() *LogClient {
-	client := &LogClient{&StatsdClient{muted: true}}
+func NewLogClient(unicode bool) *LogClient {
+	client := &LogClient{&StatsdClient{muted: true, unicode: unicode}}
 	client.ResetHTTPRequestSection()
 
 	return client

--- a/log_client_test.go
+++ b/log_client_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestNewLogClient_SetHTTPMetricCallback(t *testing.T) {
-	client := NewLogClient()
+	client := NewLogClient(true)
 	callback := func(metricParts bucket.MetricOperation, r *http.Request) bucket.MetricOperation {
 		return metricParts
 	}

--- a/memory_client_test.go
+++ b/memory_client_test.go
@@ -12,19 +12,19 @@ import (
 )
 
 func TestMemoryClient_BuildTimeTracker(t *testing.T) {
-	client := NewMemoryClient()
+	client := NewMemoryClient(true)
 	tt := client.BuildTimer()
 	_, ok := tt.(*timer.Memory)
 	assert.True(t, ok)
 }
 
 func TestMemoryClient_TrackRequest(t *testing.T) {
-	client := NewMemoryClient()
+	client := NewMemoryClient(true)
 
 	tt := client.BuildTimer()
 	r := &http.Request{Method: http.MethodGet, URL: &url.URL{Path: "/hello/memory/test"}}
 	success := true
-	b := bucket.NewHTTPRequest(client.httpRequestSection, r, success, client.httpMetricCallback)
+	b := bucket.NewHTTPRequest(client.httpRequestSection, r, success, client.httpMetricCallback, false)
 
 	client.TrackRequest(r, tt, success)
 
@@ -44,13 +44,13 @@ func TestMemoryClient_TrackRequest(t *testing.T) {
 }
 
 func TestMemoryClient_TrackOperation(t *testing.T) {
-	client := NewMemoryClient()
+	client := NewMemoryClient(true)
 
 	tt := client.BuildTimer()
 	section := "test-section"
 	operation := bucket.MetricOperation{"o1", "o2", "o3"}
 	success := true
-	b := bucket.NewPlain(section, operation, success)
+	b := bucket.NewPlain(section, operation, success, true)
 
 	client.TrackOperation(section, operation, tt, success)
 
@@ -70,14 +70,14 @@ func TestMemoryClient_TrackOperation(t *testing.T) {
 }
 
 func TestMemoryClient_TrackOperationN(t *testing.T) {
-	client := NewMemoryClient()
+	client := NewMemoryClient(true)
 
 	tt := client.BuildTimer()
 	section := "test-section"
 	operation := bucket.MetricOperation{"o1", "o2", "o3"}
 	success := true
 	n := 5
-	b := bucket.NewPlain(section, operation, success)
+	b := bucket.NewPlain(section, operation, success, true)
 
 	client.TrackOperationN(section, operation, tt, n, success)
 
@@ -97,11 +97,11 @@ func TestMemoryClient_TrackOperationN(t *testing.T) {
 }
 
 func TestMemoryClient_TrackMetric(t *testing.T) {
-	client := NewMemoryClient()
+	client := NewMemoryClient(true)
 
 	section := "test-section"
 	operation := bucket.MetricOperation{"o1", "o2", "o3"}
-	b := bucket.NewPlain(section, operation, true)
+	b := bucket.NewPlain(section, operation, true, true)
 
 	client.TrackMetric(section, operation)
 
@@ -120,12 +120,12 @@ func TestMemoryClient_TrackMetric(t *testing.T) {
 }
 
 func TestMemoryClient_TrackMetricN(t *testing.T) {
-	client := NewMemoryClient()
+	client := NewMemoryClient(true)
 
 	section := "test-section"
 	operation := bucket.MetricOperation{"o1", "o2", "o3"}
 	n := 5
-	b := bucket.NewPlain(section, operation, true)
+	b := bucket.NewPlain(section, operation, true, true)
 
 	client.TrackMetricN(section, operation, n)
 
@@ -144,7 +144,7 @@ func TestMemoryClient_TrackMetricN(t *testing.T) {
 }
 
 func TestMemoryClient_TrackState(t *testing.T) {
-	client := NewMemoryClient()
+	client := NewMemoryClient(true)
 
 	section := "test-section"
 	operation1 := bucket.MetricOperation{"o1", "o2", "o3"}
@@ -157,17 +157,17 @@ func TestMemoryClient_TrackState(t *testing.T) {
 	client.TrackState(section, operation2, state2)
 
 	assert.Equal(t, 2, len(client.StateMetrics))
-	assert.Equal(t, state1, client.StateMetrics[bucket.NewPlain(section, operation1, true).Metric()])
-	assert.Equal(t, state2, client.StateMetrics[bucket.NewPlain(section, operation2, true).Metric()])
+	assert.Equal(t, state1, client.StateMetrics[bucket.NewPlain(section, operation1, true, true).Metric()])
+	assert.Equal(t, state2, client.StateMetrics[bucket.NewPlain(section, operation2, true, true).Metric()])
 
 	client.TrackState(section, operation1, state12)
 	assert.Equal(t, 2, len(client.StateMetrics))
-	assert.Equal(t, state12, client.StateMetrics[bucket.NewPlain(section, operation1, true).Metric()])
-	assert.Equal(t, state2, client.StateMetrics[bucket.NewPlain(section, operation2, true).Metric()])
+	assert.Equal(t, state12, client.StateMetrics[bucket.NewPlain(section, operation1, true, true).Metric()])
+	assert.Equal(t, state2, client.StateMetrics[bucket.NewPlain(section, operation2, true, true).Metric()])
 }
 
 func TestMemoryClient_SetHTTPMetricCallback(t *testing.T) {
-	client := NewMemoryClient()
+	client := NewMemoryClient(true)
 	callback := func(metricParts bucket.MetricOperation, r *http.Request) bucket.MetricOperation {
 		return metricParts
 	}
@@ -181,7 +181,7 @@ func TestMemoryClient_SetHTTPMetricCallback(t *testing.T) {
 }
 
 func TestMemoryClient_SetHTTPRequestSection(t *testing.T) {
-	client := NewMemoryClient()
+	client := NewMemoryClient(true)
 
 	assert.Equal(t, bucket.SectionRequest, client.httpRequestSection)
 

--- a/noop_client.go
+++ b/noop_client.go
@@ -11,12 +11,14 @@ import (
 // NoopClient is Client implementation that does literally nothing
 type NoopClient struct {
 	sync.Mutex
+
+	unicode            bool
 	httpMetricCallback bucket.HTTPMetricNameAlterCallback
 }
 
 // NewNoopClient builds and returns new NoopClient instance
-func NewNoopClient() *NoopClient {
-	return &NoopClient{}
+func NewNoopClient(unicode bool) *NoopClient {
+	return &NoopClient{unicode: unicode}
 }
 
 // BuildTimer builds timer to track metric timings

--- a/noop_client_test.go
+++ b/noop_client_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestNoopClient(t *testing.T) {
-	client := NewNoopClient()
+	client := NewNoopClient(true)
 
 	assert.Nil(t, client.Close())
 	assert.IsType(t, &timer.Memory{}, client.BuildTimer())
@@ -29,7 +29,7 @@ func TestNoopClient(t *testing.T) {
 }
 
 func TestNewNoopClient_SetHTTPMetricCallback(t *testing.T) {
-	client := NewNoopClient()
+	client := NewNoopClient(true)
 	callback := func(metricParts bucket.MetricOperation, r *http.Request) bucket.MetricOperation {
 		return metricParts
 	}


### PR DESCRIPTION
Made unicode ASCIIsation optional and disabled by default as it requires significant (20) memory allocations. Additionally made some improvements to bucket metrics generation to reduce memory allocations from 2-6 to 0.

**Connection DSN also sligtly changed, see details in README**

Master branch:

```
$ go test -bench . -benchmem
goos: darwin
goarch: amd64
pkg: github.com/hellofresh/stats-go/bucket
BenchmarkNewHTTPRequest-8                 	 1000000	      1339 ns/op	     304 B/op	      34 allocs/op
BenchmarkHttpRequest_MetricWithSuffix-8   	  500000	      3796 ns/op	    1184 B/op	      80 allocs/op
BenchmarkHttpRequest_MetricTotal-8        	  500000	      3011 ns/op	     672 B/op	      72 allocs/op
BenchmarkNewPlain-8                       	 2000000	       833 ns/op	     144 B/op	      22 allocs/op
BenchmarkPlain_Metric-8                   	10000000	       185 ns/op	      48 B/op	       3 allocs/op
BenchmarkPlain_MetricWithSuffix-8         	 3000000	       538 ns/op	     288 B/op	       6 allocs/op
BenchmarkPlain_MetricTotal-8              	10000000	       149 ns/op	      32 B/op	       2 allocs/op
BenchmarkPlain_MetricTotalWithSuffix-8    	 3000000	       501 ns/op	     256 B/op	       5 allocs/op
PASS
ok  	github.com/hellofresh/stats-go/bucket	15.257s
```

This branch

```
$ go test -bench . -benchmem
goos: darwin
goarch: amd64
pkg: github.com/hellofresh/stats-go/bucket
BenchmarkNewHTTPRequest-8                	 3000000	       489 ns/op	     175 B/op	       6 allocs/op
BenchmarkNewHTTPRequest_unicode-8        	 1000000	      1361 ns/op	     304 B/op	      34 allocs/op
BenchmarkNewPlain-8                      	10000000	       229 ns/op	      64 B/op	       2 allocs/op
BenchmarkNewPlain_unicode-8              	 2000000	       825 ns/op	     144 B/op	      22 allocs/op
BenchmarkPlain_Metric-8                  	50000000	        28.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkPlain_MetricWithSuffix-8        	20000000	        63.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkPlain_MetricTotal-8             	100000000	        21.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkPlain_MetricTotalWithSuffix-8   	30000000	        57.4 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/hellofresh/stats-go/bucket	15.065s
```