### PR TITLE
Client is ignoring the address and going through localhost

### DIFF
--- a/client/statsd.go
+++ b/client/statsd.go
@@ -22,11 +22,15 @@ type StatsD struct {
 }
 
 // NewStatsD builds and returns new StatsD instance
-func NewStatsD(addr, prefix string, unicode bool) (*StatsD, error) {
+func NewStatsD(addr string, prefix string, unicode bool) (*StatsD, error) {
 	var options []statsd.Option
 
 	if prefix != "" {
 		options = append(options, statsd.Prefix(prefix))
+	}
+
+	if addr != "" {
+		options = append(options, statsd.Address(addr))
 	}
 
 	log.Log("Trying to connect to statsd instance", map[string]interface{}{


### PR DESCRIPTION
Hello guys,
I stumbled upon an issue with the library.
We are always going to localhost:8125 because we are not passing the address to StatsD client.

Can you confirm that, please?