### PR TITLE
Add ability to use arbitrary start time to track operations

### DIFF
--- a/timer/log.go
+++ b/timer/log.go
@@ -11,6 +11,12 @@ type Log struct {
 	timerStart time.Time
 }
 
+// StartAt starts timer at a given time
+func (t *Log) StartAt(s time.Time) Timer {
+	t.timerStart = s
+	return t
+}
+
 // Start starts timer
 func (t *Log) Start() Timer {
 	t.timerStart = time.Now()

--- a/timer/memory.go
+++ b/timer/memory.go
@@ -16,6 +16,12 @@ type Memory struct {
 	elapsed time.Duration
 }
 
+// StartAt starts timer at a given time
+func (t *Memory) StartAt(s time.Time) Timer {
+	t.timerStart = s
+	return t
+}
+
 // Start starts timer
 func (t *Memory) Start() Timer {
 	t.timerStart = time.Now()

--- a/timer/statsd.go
+++ b/timer/statsd.go
@@ -1,13 +1,15 @@
 package timer
 
 import (
+	"time"
+
 	"gopkg.in/alexcesaro/statsd.v2"
 )
 
 // StatsD struct is Timer interface implementation that writes all timings to statsd
 type StatsD struct {
-	timer statsd.Timing
-	c     *statsd.Client
+	timerStart time.Time
+	c          *statsd.Client
 }
 
 // NewStatsD creates new statsd timer instance
@@ -15,13 +17,19 @@ func NewStatsD(c *statsd.Client) *StatsD {
 	return &StatsD{c: c}
 }
 
+// StartAt starts timer at a given time
+func (t *StatsD) StartAt(s time.Time) Timer {
+	t.timerStart = s
+	return t
+}
+
 // Start starts timer
 func (t *StatsD) Start() Timer {
-	t.timer = t.c.NewTiming()
+	t.timerStart = time.Now()
 	return t
 }
 
 // Finish writes elapsed time for metric to statsd
 func (t *StatsD) Finish(bucket string) {
-	t.timer.Send(bucket)
+	t.c.Timing(bucket, int(time.Now().Sub(t.timerStart)/time.Millisecond))
 }

--- a/timer/timer.go
+++ b/timer/timer.go
@@ -1,9 +1,13 @@
 package timer
 
+import "time"
+
 // Timer is a metric time tracking interface
 type Timer interface {
 	// Start starts timer
 	Start() Timer
+	// StartAt starts timer at a given time
+	StartAt(time.Time) Timer
 	// Finish writes elapsed time for metric
 	Finish(bucket string)
 }


### PR DESCRIPTION
Hi there, =)

For some operations we won't have an option to have a `*timer.Timer` from `statsClient.BuildTimer().Start()` when we need to send `statsClient.TrackOperation(s, i, timer, false)`. 

Example:
- When we need to track asynchronous tasks in general. E.g: The time of an entire flow of messages being exchanged between two services/systems.

This PR aims to archive that by allowing users to create a `*timer.Timer` passing a given arbitrary time as in `statsClient.BuildTimer().FromArbitraryStart(time.Time)`.

As embedding `statsd.Timing` struct wouldn't be enough due to the fact that the start time field being unexported on `statsd` remote package, I thought the best idea would be to fork `statsd` project and make the changes I needed on the fork. Another fact that helped in that decision is that the project maintainer's last merged a PR was 2 years ago, so I don't think sending a PR would work.

The changes can be found made to `statsd` can be found at https://github.com/brunomvsouza/statsd/commit/409b9082ea98e569a872b15e5a6244817e1fadc7. 
Please let me know if I should make the fork HelloFresh's instead of mine. 🙇 

Cheers! 🍻 