### PR TITLE
Prometheus version from 0.9.2 to 1.1.0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -71,10 +71,11 @@
   packages = [
     "prometheus",
     "prometheus/internal",
+    "prometheus/promhttp",
   ]
   pruneopts = ""
   revision = "505eaef017263e299324067d40ca2c48f6a2cf50"
-  version = "v0.9.2"
+  version = "v1.1.0"
 
 [[projects]]
   branch = "master"
@@ -162,6 +163,7 @@
     "github.com/felixge/httpsnoop",
     "github.com/fiam/gounidecode/unidecode",
     "github.com/prometheus/client_golang/prometheus",
+    "github.com/prometheus/client_golang/prometheus/promhttp",
     "github.com/sirupsen/logrus",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -43,4 +43,4 @@
 
 [[constraint]]
   name = "github.com/prometheus/client_golang"
-  version = "0.9.2"
+  version = "1.1.0"

--- a/client/prometheus.go
+++ b/client/prometheus.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hellofresh/stats-go/state"
 	"github.com/hellofresh/stats-go/timer"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 // Prometheus is Client implementation for prometheus
@@ -266,5 +267,5 @@ func (c *Prometheus) ResetHTTPRequestSection() Client {
 
 // Handler returns metrics endpoint for prometheus backend
 func (c *Prometheus) Handler() http.Handler {
-	return prometheus.Handler()
+	return promhttp.Handler()
 }


### PR DESCRIPTION
prometheus v1.1.0 move the `Handler()` function to sub package `promhttp`